### PR TITLE
add missing log files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# Include log files in extdata
+!inst/extdata/**/*.log
+
 # History files
 .Rhistory
 .Rapp.history

--- a/inst/extdata/Breast_Cancer_3p_LT/alevinfry_intron_filtered/alevin/alevin.log
+++ b/inst/extdata/Breast_Cancer_3p_LT/alevinfry_intron_filtered/alevin/alevin.log
@@ -1,0 +1,7 @@
+[2021-07-13 20:39:26.274] [alevinLog] [info] The --rad flag was passed to alevin. The reads will be selectively aligned and the output written to a RAD file.Arguments passed that correspond to other processing steps will be ignored
+[2021-07-13 20:39:26.274] [alevinLog] [info] The --sketch flag was passed; the alignment will be run in sketch mode.
+[2021-07-13 20:39:26.809] [alevinLog] [info] Found 621107 transcripts(+0 decoys, +39 short and +0 duplicate names in the index)
+[2021-07-13 20:39:27.246] [alevinLog] [info] Filled with 621146 txp to gene entries 
+[2021-07-13 20:39:27.376] [alevinLog] [info] Found all transcripts to gene mappings
+[2021-07-13 20:39:27.434] [alevinLog] [info] parsing read library format
+[2021-07-13 20:41:19.547] [alevinLog] [info] sc-align successful.

--- a/inst/extdata/Breast_Cancer_3p_LT/alevinfry_intron_filtered/logs/salmon_quant.log
+++ b/inst/extdata/Breast_Cancer_3p_LT/alevinfry_intron_filtered/logs/salmon_quant.log
@@ -1,0 +1,22 @@
+[2021-07-13 20:39:26.297] [jointLog] [info] setting maxHashResizeThreads to 8
+[2021-07-13 20:39:26.297] [jointLog] [info] Fragment incompatibility prior below threshold.  Incompatible fragments will be ignored.
+[2021-07-13 20:39:26.297] [jointLog] [info] The --mimicBT2, --mimicStrictBT2 and --hardFilter flags imply mapping validation (--validateMappings). Enabling mapping validation.
+[2021-07-13 20:39:26.297] [jointLog] [info] Usage of --validateMappings implies use of minScoreFraction. Since not explicitly specified, it is being set to 0.65
+[2021-07-13 20:39:26.297] [jointLog] [info] The use of range-factorized equivalence classes does not make sense in conjunction with --hardFilter.  Disabling range-factorized equivalence classes. 
+[2021-07-13 20:39:26.297] [jointLog] [info] Setting consensusSlack to selective-alignment default of 0.35.
+[2021-07-13 20:39:26.297] [jointLog] [info] Using default value of 0.87 for minScoreFraction in Alevin
+Using default value of 0.6 for consensusSlack in Alevin
+[2021-07-13 20:39:27.434] [jointLog] [info] There is 1 library.
+[2021-07-13 20:39:27.531] [jointLog] [info] Loading pufferfish index
+[2021-07-13 20:39:27.531] [jointLog] [info] Loading dense pufferfish index.
+[2021-07-13 20:39:58.503] [jointLog] [info] done
+[2021-07-13 20:39:58.503] [jointLog] [info] Index contained 621146 targets
+[2021-07-13 20:39:58.743] [jointLog] [info] Number of decoys : 0
+[2021-07-13 20:41:18.390] [jointLog] [info] Number uniquely mapped : 12762841
+[2021-07-13 20:41:18.412] [jointLog] [info] Computed 0 rich equivalence classes for further processing
+[2021-07-13 20:41:18.412] [jointLog] [info] Counted 0 total reads in the equivalence classes 
+[2021-07-13 20:41:18.413] [jointLog] [info] Selectively-aligned 39012555 total fragments out of 42854607
+[2021-07-13 20:41:18.413] [jointLog] [info] Number of fragments discarded because they are best-mapped to decoys : 0
+[2021-07-13 20:41:18.413] [jointLog] [warning] Found 1917 reads with `N` in the UMI sequence and ignored the reads.
+Please report on github if this number is too large
+[2021-07-13 20:41:18.413] [jointLog] [info] finished sc_align()

--- a/inst/extdata/Breast_Cancer_3p_LT/alevinfry_usa_filtered/alevin/alevin.log
+++ b/inst/extdata/Breast_Cancer_3p_LT/alevinfry_usa_filtered/alevin/alevin.log
@@ -1,0 +1,7 @@
+[2021-07-13 19:24:18.970] [alevinLog] [info] The --rad flag was passed to alevin. The reads will be selectively aligned and the output written to a RAD file.Arguments passed that correspond to other processing steps will be ignored
+[2021-07-13 19:24:18.970] [alevinLog] [info] The --sketch flag was passed; the alignment will be run in sketch mode.
+[2021-07-13 19:24:19.493] [alevinLog] [info] Found 621107 transcripts(+0 decoys, +39 short and +0 duplicate names in the index)
+[2021-07-13 19:24:19.924] [alevinLog] [info] Filled with 621146 txp to gene entries 
+[2021-07-13 19:24:20.042] [alevinLog] [info] Found all transcripts to gene mappings
+[2021-07-13 19:24:20.098] [alevinLog] [info] parsing read library format
+[2021-07-13 19:26:11.257] [alevinLog] [info] sc-align successful.

--- a/inst/extdata/Breast_Cancer_3p_LT/alevinfry_usa_filtered/logs/salmon_quant.log
+++ b/inst/extdata/Breast_Cancer_3p_LT/alevinfry_usa_filtered/logs/salmon_quant.log
@@ -1,0 +1,22 @@
+[2021-07-13 19:24:18.993] [jointLog] [info] setting maxHashResizeThreads to 8
+[2021-07-13 19:24:18.993] [jointLog] [info] Fragment incompatibility prior below threshold.  Incompatible fragments will be ignored.
+[2021-07-13 19:24:18.993] [jointLog] [info] The --mimicBT2, --mimicStrictBT2 and --hardFilter flags imply mapping validation (--validateMappings). Enabling mapping validation.
+[2021-07-13 19:24:18.993] [jointLog] [info] Usage of --validateMappings implies use of minScoreFraction. Since not explicitly specified, it is being set to 0.65
+[2021-07-13 19:24:18.993] [jointLog] [info] The use of range-factorized equivalence classes does not make sense in conjunction with --hardFilter.  Disabling range-factorized equivalence classes. 
+[2021-07-13 19:24:18.993] [jointLog] [info] Setting consensusSlack to selective-alignment default of 0.35.
+[2021-07-13 19:24:18.993] [jointLog] [info] Using default value of 0.87 for minScoreFraction in Alevin
+Using default value of 0.6 for consensusSlack in Alevin
+[2021-07-13 19:24:20.098] [jointLog] [info] There is 1 library.
+[2021-07-13 19:24:20.194] [jointLog] [info] Loading pufferfish index
+[2021-07-13 19:24:20.194] [jointLog] [info] Loading dense pufferfish index.
+[2021-07-13 19:24:50.630] [jointLog] [info] done
+[2021-07-13 19:24:50.630] [jointLog] [info] Index contained 621146 targets
+[2021-07-13 19:24:50.864] [jointLog] [info] Number of decoys : 0
+[2021-07-13 19:26:10.657] [jointLog] [info] Number uniquely mapped : 12762841
+[2021-07-13 19:26:10.679] [jointLog] [info] Computed 0 rich equivalence classes for further processing
+[2021-07-13 19:26:10.679] [jointLog] [info] Counted 0 total reads in the equivalence classes 
+[2021-07-13 19:26:10.679] [jointLog] [info] Selectively-aligned 39012555 total fragments out of 42854607
+[2021-07-13 19:26:10.679] [jointLog] [info] Number of fragments discarded because they are best-mapped to decoys : 0
+[2021-07-13 19:26:10.679] [jointLog] [warning] Found 1917 reads with `N` in the UMI sequence and ignored the reads.
+Please report on github if this number is too large
+[2021-07-13 19:26:10.679] [jointLog] [info] finished sc_align()


### PR DESCRIPTION
My global `.gitignore` file was excluding log files, but we want to include those here if they are part of the `extdata` so I added them back here and modified .gitignore to include such files in the future. 

They may not be needed (see https://github.com/AlexsLemonade/scpcaTools/pull/13/commits/12172765f2ec4821fb2eca28393cb6682454cd41), but it seems better to have them there in case.